### PR TITLE
Disable events as a workaround for OCP 4.3 support

### DIFF
--- a/.workshop/jupyterhub_config.py
+++ b/.workshop/jupyterhub_config.py
@@ -1,0 +1,1 @@
+c.KubeSpawner.events_enabled = False


### PR DESCRIPTION
As per: https://github.com/openshift-homeroom/workshop-spawner/issues/29#issuecomment-594199226
Seems to work on OCP 4.3.0 and 4.2.10